### PR TITLE
Add check for presence of Rosetta2, fix spelling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,8 @@ execute() {
   install "${srcdir}/${binexe}" "${BINDIR}/" 2> /dev/null || sudo install "${srcdir}/${binexe}" "${BINDIR}/"
   log_info "Installed ${BINDIR}/${binexe}"
   if [ "$ORIG_PLATFORM" = "darwin/arm64" ]; then
-    log_info "M1 CPU requires Rosseta 2, make sure you have, or install it by running: '/usr/sbin/softwareupdate --install-rosetta'"
+    # test if Rosetta2 is present
+    /usr/bin/pgrep -q oahd || log_info "M1 CPU requires Rosetta 2, which appears to be missing.  Install it by running: '/usr/sbin/softwareupdate --install-rosetta'"
   fi
 
 }


### PR DESCRIPTION
In the install script for orca-cli, I get this on my M1 Mac:

`bash info Installed /usr/local/bin/orca-cli
bash info M1 CPU requires Rosseta 2, make sure you have, or install it by running: '/usr/sbin/softwareupdate --install-rosetta'`

It took me running the installer twice and reinstalling Rosetta once to realize that this was a successful install and the line about installing Rosetta was just informational so I added a check for Rosetta2 to only print that warning if it's not present on the machine.