### PR TITLE
remove the tmpdir after orca-cli installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ execute() {
     # test if Rosetta2 is present
     /usr/bin/pgrep -q oahd || log_info "M1 CPU requires Rosetta 2, which appears to be missing.  Install it by running: '/usr/sbin/softwareupdate --install-rosetta'"
   fi
-
+  rm -rf "${tmpdir}"
 }
 
 


### PR DESCRIPTION
Instructions to remove the tmp directory used for downloading and extracting orca-cli tool: rm -rf "${tmpdir}"